### PR TITLE
relax parsing and add cookie note

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Requires Node 18.
 cp .env.template .env
 ```
 
-(optional) Insert your `connect.sid` cookie value from your browser, as a value of the `CONNECT_SID` environment variable. This is needed for the script to access paywalled posts.
+(optional) Insert your `connect.sid` cookie value from your browser, as a value of the `CONNECT_SID` environment variable. This is needed for the script to access paywalled posts. Note: Each substack has its own connect.sid cookie value.
 
 ```
 npm run build

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const Archive = z.array(
     canonical_url: z.string().url(),
     slug: z.string(),
     post_date: z.string().datetime(),
-    subtitle: z.string(),
+    subtitle: z.string().nullable(),
     publication_id: z.number(),
   })
 );
@@ -36,6 +36,7 @@ do {
   const response = await fetch(api, {
     headers: { cookie: `connect.sid=${process.env.CONNECT_SID}` },
   });
+  console.log(`📡 ${response.status} ${response.statusText}`);
   fetchedArticles = await response.json();
   articles.push(...Archive.parse(fetchedArticles));
   offset += limit;
@@ -101,7 +102,13 @@ for (const article of articles) {
   const obsidianText = mdText.replace(
     /\[([^\]]+)\]\(([^\)]+)\)/g,
     (_, linkText, link) => {
-      const url = new URL(link);
+      let url: URL;
+      try {
+        url = new URL(link);
+      } catch (error) {
+        console.error(`Error parsing URL: ${error}`);
+        return `[${linkText}](${link})`;
+      }
       const linkedArticle = articles.find(
         (article) => url.pathname === `/p/${article.slug}`
       );


### PR DESCRIPTION
When downloading a substack archive I found that some articles didn't have subtitles or had invalid URLs. This should now handle those cases by reporting issues instead of failing fast.